### PR TITLE
Added support for custom constructors

### DIFF
--- a/source/painlessjson/painlessjson.d
+++ b/source/painlessjson/painlessjson.d
@@ -574,3 +574,11 @@ unittest
     assert(person.id == 34);
     assert(person.name == "Jason Pain");
 }
+
+/// Multiple constructors and some JSON-values are missing
+unittest
+{
+    auto person = fromJSON!IdAndName(parseJSON(q{{"id":34}}));
+    assert(person.id == 34);
+    assert(person.name == "Undefined");
+}

--- a/source/painlessjson/painlessjson.d
+++ b/source/painlessjson/painlessjson.d
@@ -355,7 +355,7 @@ private T fromJSONImpl(T)(JSONValue json) if(!isBuiltinType!T && !is(T==JSONValu
         {
             alias Overloads = TypeTuple!(__traits(getOverloads, T, "__ctor"));
             alias T function(JSONValue value) @system constructorFunctionType;
-            int bestOverloadScore = int.max;
+            ulong bestOverloadScore = ulong.max;
             constructorFunctionType bestOverload;
             foreach(overload ; Overloads)
             {
@@ -363,7 +363,7 @@ private T fromJSONImpl(T)(JSONValue json) if(!isBuiltinType!T && !is(T==JSONValu
                 {
                     if(jsonValueHasAllFieldsNeeded!(overload)(json))
                     {
-                        int overloadScore = constructorOverloadScore!(overload)(json);
+                        ulong overloadScore = constructorOverloadScore!(overload)(json);
                         if(overloadScore<bestOverloadScore)
                         {
                             bestOverload = function(JSONValue value)
@@ -375,7 +375,7 @@ private T fromJSONImpl(T)(JSONValue json) if(!isBuiltinType!T && !is(T==JSONValu
                     }
                 }
             }
-            if(bestOverloadScore<int.max)
+            if(bestOverloadScore<ulong.max)
             {
                 return bestOverload(json);
             }
@@ -465,14 +465,14 @@ bool jsonValueHasAllFieldsNeeded(alias Ctor)(JSONValue json)
     return true;
 }
 
-int constructorOverloadScore(alias Ctor)(JSONValue json)
+ulong constructorOverloadScore(alias Ctor)(JSONValue json)
 {
     import std.typecons : staticIota;
     enum params = ParameterIdentifierTuple!(Ctor);
     alias defaults = ParameterDefaultValueTuple!(Ctor);
     alias Types = ParameterTypeTuple!(Ctor);
     Tuple!(Types) args;
-    int overloadScore = json.object.length;
+    ulong overloadScore = json.object.length;
 
     foreach(i ; staticIota!(0, params.length))
     {

--- a/source/painlessjson/painlessjson.d
+++ b/source/painlessjson/painlessjson.d
@@ -406,7 +406,7 @@ T getInstanceFromCustomConstructor(T, alias Ctor)(JSONValue json)
     foreach(i ; staticIota!(0, params.length))
     {
         enum paramName = params[i];
-        if (paramName in json)
+        if (paramName in json.object)
         {
             args[i] = fromJSON!(Types[i])(json[paramName]);
         }

--- a/source/painlessjson/painlessjson.d
+++ b/source/painlessjson/painlessjson.d
@@ -566,3 +566,11 @@ unittest
     assert(p.x == 2);
     assert(p.y == 5);
 }
+
+/// Multiple constructors and all JSON-values are there
+unittest
+{
+    auto person = fromJSON!IdAndName(parseJSON(q{{"id":34, "name": "Jason Pain"}}));
+    assert(person.id == 34);
+    assert(person.name == "Jason Pain");
+}

--- a/source/painlessjson/painlessjson.d
+++ b/source/painlessjson/painlessjson.d
@@ -490,3 +490,11 @@ unittest
 	point[1] = 6;
 	assert(point== fromJSON!(Tuple!(int,int))(parseJSON(q{{"_0":5,"_1":6}})));
 }
+
+/// No default constructor
+unittest
+{
+    auto p = fromJSON!PointUseConstructor(parseJSON(q{{"x":2, "y":5}}));
+    assert(p.x == 2);
+    assert(p.y == 5);
+}

--- a/source/painlessjson/painlessjson.d
+++ b/source/painlessjson/painlessjson.d
@@ -351,7 +351,6 @@ private T fromJSONImpl(T)(JSONValue json) if(!isBuiltinType!T && !is(T==JSONValu
         return t;
     } else static if(hasAccessibleConstructor!T)
     {
-        pragma(msg, "hasAccessibleConstructor");
         if (__traits(hasMember, T, "__ctor"))
         {
             alias Overloads = TypeTuple!(__traits(getOverloads, T, "__ctor"));

--- a/source/painlessjson/painlessjson.d
+++ b/source/painlessjson/painlessjson.d
@@ -326,14 +326,9 @@ private T fromJSONImpl(T)(JSONValue json) if(!isBuiltinType!T && !is(T==JSONValu
     {
         return T._fromJSON(json);
     }
-    else
+    else static if(hasAccessibleDefaultsConstructor!(T))
     {
-        T t;
-        static if (is(T==class) && __traits(compiles,
-            new T))
-        {
-            t = new T;
-        }
+        T t = getIntstanceFromDefaultConstructor!T;
         
         
             mixin ("JSONValue[string] jsonAA = json.object;");
@@ -363,6 +358,30 @@ T fromJSON(T)(JSONValue json){
     return fromJSONImpl!T(json);
 }
 
+
+template hasAccessibleDefaultsConstructor(T)
+{
+    static bool helper()
+    {
+        return (is(T==struct) && __traits(compiles,{T t;}))
+            || (is(T==class) && __traits(compiles, {T t = new T;}));
+    }
+
+    enum bool hasAccessibleDefaultsConstructor = helper();
+}
+
+T getIntstanceFromDefaultConstructor(T)()
+{
+    static if(is(T==struct) && __traits(compiles,{T t;}))
+    {
+        return T();
+    } else static if(is(T==class) && __traits(compiles, {T t = new T;}))
+    {
+        return new T();
+    }
+
+
+}
 
 /// Converting common types
 unittest

--- a/source/painlessjson/unittesttypes.d
+++ b/source/painlessjson/unittesttypes.d
@@ -229,6 +229,12 @@ struct IdAndName
     @disable this();
     string name; ///
     int id; ///
+    
+    this(string name)
+    {
+        assert( 0 );
+    }
+    
     this(int id, string name)
     {
         this.id = id;
@@ -240,5 +246,4 @@ struct IdAndName
         this.id = id;
         this.name = "Undefined";
     }
-
 }

--- a/source/painlessjson/unittesttypes.d
+++ b/source/painlessjson/unittesttypes.d
@@ -196,3 +196,29 @@ struct PointSerializationIgnore
     }
 
 }
+
+///
+struct PointUseConstructor
+{
+    @disable this();
+    double x = 0; ///
+    double y = 1; ///
+    this(double x, double y)
+    {
+        this.x = x;
+        this.y = y;
+    }
+
+    string foo()
+    {
+        writeln("Functions should not be called");
+        return "Noooooo!";
+    }
+
+    static string bar()
+    {
+        writeln("Static functions should not be called");
+        return "Noooooo!";
+    }
+
+}

--- a/source/painlessjson/unittesttypes.d
+++ b/source/painlessjson/unittesttypes.d
@@ -222,3 +222,23 @@ struct PointUseConstructor
     }
 
 }
+
+///
+struct IdAndName
+{
+    @disable this();
+    string name; ///
+    int id; ///
+    this(int id, string name)
+    {
+        this.id = id;
+        this.name = name;
+    }
+
+    this(int id)
+    {
+        this.id = id;
+        this.name = "Undefined";
+    }
+
+}


### PR DESCRIPTION
This adds support for finding and using a custom constructor when the default is disabled. I want to improve this in the future by having options for emitting errors when a json field is not used etc.
