### PR TITLE
[RFC] Default from json

### DIFF
--- a/source/painlessjson/painlessjson.d
+++ b/source/painlessjson/painlessjson.d
@@ -27,8 +27,9 @@ JSONValue defaultToJSON(T)(in T object) if (__traits(compiles, (in T t) {
 }
 
 //See if we can use something else than !__traits(compiles, (T t){JSONValue(t);})
-JSONValue defaultToJSON(T)(in T object) if (isArray!T
-        && !__traits(compiles, (in T t) { JSONValue(t); }))
+JSONValue defaultToJSON(T)(in T object) if (isArray!T && !__traits(compiles, (in T t) {
+    JSONValue(t);
+}))
 {
     JSONValue[] jsonRange;
     jsonRange = map!((el) => el.toJSON)(object).array;
@@ -55,15 +56,15 @@ JSONValue defaultToJSON(T)(in T object) if (!isBuiltinType!T
     foreach (name; __traits(allMembers, T))
     {
         static if (__traits(compiles,
-                    {
-                    json[serializationToName!(__traits(getMember, object, name),
-                            name)] = __traits(getMember, object, name).toJSON;
-                    }) && !hasAnyOfTheseAnnotations!(__traits(getMember,
-                            object, name), SerializeIgnore, SerializeToIgnore)
-                && isFieldOrProperty!(__traits(getMember, object, name)))
+                {
+                    json[serializationToName!(__traits(getMember, object, name), name)] = __traits(getMember,
+                        object, name).toJSON;
+                }) && !hasAnyOfTheseAnnotations!(__traits(getMember, object,
+            name), SerializeIgnore, SerializeToIgnore)
+            && isFieldOrProperty!(__traits(getMember, object, name)))
         {
             json[serializationToName!(__traits(getMember, object, name), name)] = __traits(getMember,
-                    object, name).toJSON;
+                object, name).toJSON;
         }
     }
     return JSONValue(json);
@@ -123,8 +124,8 @@ unittest
     PointPrivate p = new PointPrivate(-1, 2);
     assertEqual(toJSON(p).toString, q{{"x":-1,"y":2}});
     auto pnt = p.toJSON.fromJSON!PointPrivate;
-    assertEqual( p.x, -1 );
-    assertEqual( p.y, 2 );
+    assertEqual(p.x, -1);
+    assertEqual(p.y, 2);
 }
 
 /// User class with defaultToJSON
@@ -133,8 +134,8 @@ unittest
     PointDefaultFromJSON p = new PointDefaultFromJSON(-1, 2);
     assertEqual(toJSON(p).toString, q{{"_x":-1,"y":2}});
     auto pnt = p.toJSON.fromJSON!PointDefaultFromJSON;
-    assertEqual( p.x, -1 );
-    assertEqual( p.y, 2 );
+    assertEqual(p.x, -1);
+    assertEqual(p.y, 2);
 }
 
 /// User class with private fields and @property
@@ -246,9 +247,9 @@ unittest
     }
 
     auto z = new Z;
-    assertEqual( z.toJSON["x"].floating, 0 );
-    assertEqual( z.toJSON["y"].floating, 1 );
-    assertEqual( z.toJSON["add"].str, "bla" );
+    assertEqual(z.toJSON["x"].floating, 0);
+    assertEqual(z.toJSON["y"].floating, 1);
+    assertEqual(z.toJSON["add"].str, "bla");
 }
 
 T defaultFromJSON(T)(in JSONValue json) if (is(T == JSONValue))
@@ -364,7 +365,8 @@ T defaultFromJSON(T)(in JSONValue json) if (!isBuiltinType!T &&  !is(T == JSONVa
             {
                 return bestOverload(json);
             }
-            throw new JSONException("JSONValue can't satisfy any constructor: " ~ json.toPrettyString);
+            throw new JSONException(
+                "JSONValue can't satisfy any constructor: " ~ json.toPrettyString);
         }
     }
 }

--- a/source/painlessjson/painlessjson.d
+++ b/source/painlessjson/painlessjson.d
@@ -19,7 +19,7 @@ version (unittest)
 }
 
 //See if we can use something else than __traits(compiles, (T t){JSONValue(t);})
-JSONValue defaultToJSONImpl(T)(in T object) if (__traits(compiles, (in T t) {
+private JSONValue defaultToJSONImpl(T)(in T object) if (__traits(compiles, (in T t) {
     JSONValue(t);
 }))
 {
@@ -27,7 +27,7 @@ JSONValue defaultToJSONImpl(T)(in T object) if (__traits(compiles, (in T t) {
 }
 
 //See if we can use something else than !__traits(compiles, (T t){JSONValue(t);})
-JSONValue defaultToJSONImpl(T)(in T object) if (isArray!T && !__traits(compiles, (in T t) {
+private JSONValue defaultToJSONImpl(T)(in T object) if (isArray!T && !__traits(compiles, (in T t) {
     JSONValue(t);
 }))
 {
@@ -36,7 +36,7 @@ JSONValue defaultToJSONImpl(T)(in T object) if (isArray!T && !__traits(compiles,
     return JSONValue(jsonRange);
 }
 
-JSONValue defaultToJSONImpl(T)(in T object) if (isAssociativeArray!T)
+private JSONValue defaultToJSONImpl(T)(in T object) if (isAssociativeArray!T)
 {
     JSONValue[string] jsonAA;
     foreach (key, value; object)
@@ -46,7 +46,7 @@ JSONValue defaultToJSONImpl(T)(in T object) if (isAssociativeArray!T)
     return JSONValue(jsonAA);
 }
 
-JSONValue defaultToJSONImpl(T)(in T object) if (!isBuiltinType!T
+private JSONValue defaultToJSONImpl(T)(in T object) if (!isBuiltinType!T
         && !__traits(compiles, (in T t) { JSONValue(t); }))
 {
     JSONValue[string] json;
@@ -258,17 +258,17 @@ unittest
     assertEqual(z.toJSON["add"].str, "bla");
 }
 
-T defaultFromJSONImpl(T)(in JSONValue json) if (is(T == JSONValue))
+private T defaultFromJSONImpl(T)(in JSONValue json) if (is(T == JSONValue))
 {
     return json;
 }
 
-T defaultFromJSONImpl(T)(in JSONValue json) if (isIntegral!T)
+private T defaultFromJSONImpl(T)(in JSONValue json) if (isIntegral!T)
 {
     return to!T(json.integer);
 }
 
-T defaultFromJSONImpl(T)(in JSONValue json) if (isFloatingPoint!T)
+private T defaultFromJSONImpl(T)(in JSONValue json) if (isFloatingPoint!T)
 {
     if (json.type == JSON_TYPE.INTEGER)
         return to!T(json.integer);
@@ -276,12 +276,12 @@ T defaultFromJSONImpl(T)(in JSONValue json) if (isFloatingPoint!T)
         return to!T(json.floating);
 }
 
-T defaultFromJSONImpl(T)(in JSONValue json) if (is(T == string))
+private T defaultFromJSONImpl(T)(in JSONValue json) if (is(T == string))
 {
     return to!T(json.str);
 }
 
-T defaultFromJSONImpl(T)(in JSONValue json) if (isBoolean!T)
+private T defaultFromJSONImpl(T)(in JSONValue json) if (isBoolean!T)
 {
     if (json.type == JSON_TYPE.TRUE)
         return true;
@@ -289,13 +289,13 @@ T defaultFromJSONImpl(T)(in JSONValue json) if (isBoolean!T)
         return false;
 }
 
-T defaultFromJSONImpl(T)(in JSONValue json) if (isArray!T &&  !is(T == string))
+private T defaultFromJSONImpl(T)(in JSONValue json) if (isArray!T &&  !is(T == string))
 {
     T t; //Se is we can find another way of finding t.front
     return map!((js) => fromJSON!(typeof(t.front))(js))(json.array).array;
 }
 
-T defaultFromJSONImpl(T)(in JSONValue json) if (isAssociativeArray!T)
+private T defaultFromJSONImpl(T)(in JSONValue json) if (isAssociativeArray!T)
 {
     T t;
     const JSONValue[string] jsonAA = json.object;
@@ -310,7 +310,7 @@ T defaultFromJSONImpl(T)(in JSONValue json) if (isAssociativeArray!T)
  Convert to given type from JSON.<br />
  Can be overridden by &#95;fromJSON.
  +/
-T defaultFromJSONImpl(T)(in JSONValue json) if (!isBuiltinType!T &&  !is(T == JSONValue))
+private T defaultFromJSONImpl(T)(in JSONValue json) if (!isBuiltinType!T &&  !is(T == JSONValue))
 {
     static if (hasAccessibleDefaultsConstructor!(T))
     {

--- a/source/painlessjson/painlessjson.d
+++ b/source/painlessjson/painlessjson.d
@@ -45,6 +45,8 @@ JSONValue defaultToJSON(T)(in T object) if (isAssociativeArray!T)
     return JSONValue(jsonAA);
 }
 
+/// Convert any type to JSON
+/// Can be overridden by _toJSON
 JSONValue defaultToJSON(T)(in T object) if (!isBuiltinType!T
         && !__traits(compiles, (in T t) { JSONValue(t); }))
 {
@@ -297,6 +299,8 @@ T defaultFromJSON(T)(in JSONValue json) if (isAssociativeArray!T)
     return t;
 }
 
+/// Convert to given type from JSON
+/// Can be overridden by _fromJSON
 T defaultFromJSON(T)(in JSONValue json) if (!isBuiltinType!T &&  !is(T == JSONValue))
 {
     static if (hasAccessibleDefaultsConstructor!(T))

--- a/source/painlessjson/painlessjson.d
+++ b/source/painlessjson/painlessjson.d
@@ -46,8 +46,10 @@ JSONValue defaultToJSON(T)(in T object) if (isAssociativeArray!T)
     return JSONValue(jsonAA);
 }
 
-/// Convert any type to JSON
-/// Can be overridden by _toJSON
+/++
+ Convert any type to JSON<br />
+ Can be overridden by &#95;toJSON
+ +/
 JSONValue defaultToJSON(T)(in T object) if (!isBuiltinType!T
         && !__traits(compiles, (in T t) { JSONValue(t); }))
 {
@@ -300,8 +302,10 @@ T defaultFromJSON(T)(in JSONValue json) if (isAssociativeArray!T)
     return t;
 }
 
-/// Convert to given type from JSON
-/// Can be overridden by _fromJSON
+/++
+ Convert to given type from JSON.<br />
+ Can be overridden by &#95;fromJSON.
+ +/
 T defaultFromJSON(T)(in JSONValue json) if (!isBuiltinType!T &&  !is(T == JSONValue))
 {
     static if (hasAccessibleDefaultsConstructor!(T))
@@ -369,17 +373,6 @@ T defaultFromJSON(T)(in JSONValue json) if (!isBuiltinType!T &&  !is(T == JSONVa
                 "JSONValue can't satisfy any constructor: " ~ json.toPrettyString);
         }
     }
-}
-
-/// Convert from JSONValue to any other type
-T fromJSON(T)(in JSONValue json)
-{
-    static if (__traits(compiles, { return T._fromJSON(json); }))
-    {
-        return T._fromJSON(json);
-    }
-    else
-        return defaultFromJSON!T(json);
 }
 
 template hasAccessibleDefaultsConstructor(T)
@@ -503,6 +496,17 @@ template hasAccessibleConstructor(T)
     }
 
     enum bool hasAccessibleConstructor = helper();
+}
+
+/// Convert from JSONValue to any other type
+T fromJSON(T)(in JSONValue json)
+{
+    static if (__traits(compiles, { return T._fromJSON(json); }))
+    {
+        return T._fromJSON(json);
+    }
+    else
+        return defaultFromJSON!T(json);
 }
 
 /// Converting common types

--- a/source/painlessjson/unittesttypes.d
+++ b/source/painlessjson/unittesttypes.d
@@ -101,10 +101,29 @@ class PointDefaultFromJSON
     double _x;
     private double _y;
 
-    static PointPrivate _fromJSON(JSONValue value)
+    this() {}
+
+    this(double x_, double y_)
+    {
+        _x = x_;
+        _y = y_;
+    }
+
+    const double x()
+    {
+        return _x;
+    }
+
+    const double y()
+    {
+        return _y;
+    }
+
+
+    static PointDefaultFromJSON _fromJSON(JSONValue value)
     {
         auto pnt = defaultFromJSON!PointDefaultFromJSON( value );
-        pnt.y = fromJSON!double(value["y"]);
+        pnt._y = fromJSON!double(value["y"]);
         return pnt;
     }
 
@@ -112,7 +131,7 @@ class PointDefaultFromJSON
     {
         JSONValue[string] json;
         json = this.defaultToJSON.object;
-        json["y"] = JSONValue(y);
+        json["y"] = JSONValue(_y);
         return JSONValue(json);
     }
 }

--- a/source/painlessjson/unittesttypes.d
+++ b/source/painlessjson/unittesttypes.d
@@ -96,6 +96,28 @@ class PointPrivate
 
 }
 
+class PointDefaultFromJSON
+{
+    double _x;
+    private double _y;
+
+    static PointPrivate _fromJSON(JSONValue value)
+    {
+        auto pnt = defaultFromJSON!PointDefaultFromJSON( value );
+        pnt.y = fromJSON!double(value["y"]);
+        return pnt;
+    }
+
+    const JSONValue _toJSON()
+    {
+        JSONValue[string] json;
+        json = this.defaultToJSON.object;
+        json["y"] = JSONValue(y);
+        return JSONValue(json);
+    }
+}
+
+
 struct PointPrivateProperty
 {
     private double _x;

--- a/source/painlessjson/unittesttypes.d
+++ b/source/painlessjson/unittesttypes.d
@@ -101,7 +101,9 @@ class PointDefaultFromJSON
     double _x;
     private double _y;
 
-    this() {}
+    this()
+    {
+    }
 
     this(double x_, double y_)
     {
@@ -119,10 +121,9 @@ class PointDefaultFromJSON
         return _y;
     }
 
-
     static PointDefaultFromJSON _fromJSON(JSONValue value)
     {
-        auto pnt = defaultFromJSON!PointDefaultFromJSON( value );
+        auto pnt = defaultFromJSON!PointDefaultFromJSON(value);
         pnt._y = fromJSON!double(value["y"]);
         return pnt;
     }
@@ -135,7 +136,6 @@ class PointDefaultFromJSON
         return JSONValue(json);
     }
 }
-
 
 struct PointPrivateProperty
 {


### PR DESCRIPTION
Implement #27 to make it easier to override _fromJSON and _toJSON by providing a default implementation that people can call from within _from/toJSON
