### PR TITLE
Automatic camelCase conversion

### DIFF
--- a/source/painlessjson/annotations.d
+++ b/source/painlessjson/annotations.d
@@ -1,6 +1,7 @@
 module painlessjson.annotations;
 
 import painlessjson.traits;
+import painlessjson.string;
 
 struct SerializedToName
 {
@@ -41,7 +42,7 @@ struct SerializeFromIgnore
 {
 }
 
-template serializationToName(alias T, string defaultName)
+template serializationToName(alias T, string defaultName, bool alsoAcceptUnderscore)
 {
     static string helper()
     {
@@ -53,6 +54,9 @@ template serializationToName(alias T, string defaultName)
                 && getAnnotation!(T, SerializedToName).name)
         {
             return getAnnotation!(T, SerializedToName).name;
+        } else static if(alsoAcceptUnderscore)
+        {
+            return camelCaseToUnderscore(defaultName);
         }
         else
         {

--- a/source/painlessjson/painlessjson.d
+++ b/source/painlessjson/painlessjson.d
@@ -221,7 +221,11 @@ unittest
     CamelCaseConversion value;
     value.wasCamelCase = 5;
     value.was_underscore = 7;
-    assertEqual(value.toJSON!(CamelCaseConversion,SerializationOptions(false, true)).toString, q{{"was_camel_case":5,"was_underscore":7}}); 
+
+    auto valueAsJSON = value.toJSON!(CamelCaseConversion,SerializationOptions(false, true));
+    
+    assertEqual(valueAsJSON["was_camel_case"].integer, 5); 
+    assertEqual(valueAsJSON["was_underscore"].integer, 7);
 }
 
 /// Overloaded toJSON

--- a/source/painlessjson/string.d
+++ b/source/painlessjson/string.d
@@ -20,6 +20,7 @@ unittest {
 
 string camelCaseToUnderscore(string input){
     auto stringBuilder = appender!string;
+    stringBuilder.reserve(input.length*2);
     bool previousWasLower = false;
     foreach(c;input){
         if(previousWasLower && to!char(c).isUpper())

--- a/source/painlessjson/string.d
+++ b/source/painlessjson/string.d
@@ -23,12 +23,12 @@ string camelCaseToUnderscore(string input){
     stringBuilder.reserve(input.length*2);
     bool previousWasLower = false;
     foreach(c;input){
-        if(previousWasLower && to!char(c).isUpper())
+        if(previousWasLower && c.isUpper())
         {
             stringBuilder.put('_');
         }
 
-        if(to!char(c).isLower())
+        if(c.isLower())
         {
             previousWasLower = true;
         } else{

--- a/source/painlessjson/string.d
+++ b/source/painlessjson/string.d
@@ -1,0 +1,39 @@
+module painlessjson.string;
+
+import std.string;
+import std.conv;
+import std.array;
+import std.ascii : isLower, isUpper;
+
+version (unittest)
+{
+    import dunit.toolkit;
+
+}
+
+unittest {
+    enum hello_world = camelCaseToUnderscore("helloWorld");
+    assertEqual(hello_world,"hello_world");
+    enum my_json = camelCaseToUnderscore("myJSON");
+    assertEqual(my_json,"my_json");
+}
+
+string camelCaseToUnderscore(string input){
+    auto stringBuilder = appender!string;
+    bool previousWasLower = false;
+    foreach(c;input){
+        if(previousWasLower && to!char(c).isUpper())
+        {
+            stringBuilder.put('_');
+        }
+
+        if(to!char(c).isLower())
+        {
+            previousWasLower = true;
+        } else{
+            previousWasLower = false;
+        }
+        stringBuilder.put(c);
+    }
+    return stringBuilder.data.toLower();
+}

--- a/source/painlessjson/unittesttypes.d
+++ b/source/painlessjson/unittesttypes.d
@@ -293,3 +293,9 @@ class IdAndName
         this.name = "Undefined";
     }
 }
+
+struct CamelCaseConversion
+{
+    int wasCamelCase;
+    int was_underscore;
+}


### PR DESCRIPTION
Resolves issue #33.
I have added an option object that can be used to turn this feature on or off. It might be better to move all the functions to an object, but have free functions that make the call using the default-object.
