### PR TITLE
Fix #53: JSON_TYPE.NULL results in exception

### DIFF
--- a/source/painlessjson/painlessjson.d
+++ b/source/painlessjson/painlessjson.d
@@ -612,8 +612,20 @@ T fromJSON(T, SerializationOptions options = defaultSerializatonOptions)(in JSON
     {
         return T._fromJSON(json);
     }
-    else
+    else 
+    {
+        if (json.type == JSON_TYPE.NULL)
+            return T.init;
         return defaultFromJSON!(T,options)(json);
+    }
+}
+
+unittest {
+    struct P
+    { string name; }
+
+    auto jv = parseJSON(`{"name": null}`);
+    auto j = fromJSON!P(jv);
 }
 
 /// Converting common types


### PR DESCRIPTION
Fix #53 by returning T.init if json value is null.