### PR TITLE
Fix deprecations & unittests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,22 @@ script: "./travis.sh"
 sudo: false
 matrix:
   include:
-  - d: dmd-2.066.1
+  - d: dmd
     env:
     - secure: F1pwSI3BTHI/W0vaUNr2HeS7+25jLJiH2CF9pTW7cySKJGJkyOJ6gJkv71HYxq/cYVda8Y7qy+a//lZFQeWlEmMW4FTblXTE0qVvUzfCw3VRKLGYIMMMi2JzyWJODH+8Q2m19mS9OneZR5zL2NmopJn6wGrfUWZZuerk3XP57C0=
-  - d: dmd-2.067.1
-  - d: dmd-2.068.0
-  - d: dmd
-  - d: ldc-0.15.1
-  - d: gdc-4.9.2
+  - d: dmd-2.087.0
+  - d: dmd-2.086.1
+  - d: dmd-2.085.1
+  - d: dmd-2.084.1
+  - d: dmd-2.083.1
+  - d: dmd-2.078.3
+  - d: dmd-2.077.1
+  - d: dmd-2.076.1
+  - d: ldc
+  - d: ldc-1.16.0
+  - d: ldc-1.15.0
+  - d: ldc-1.14.0
+  - d: ldc-1.13.0
+  - d: ldc-1.7.0
+  - d: ldc-1.6.0
+

--- a/README.md
+++ b/README.md
@@ -67,12 +67,34 @@ More detailed examples can be found in the [master branch documentation on Githu
 The library uses compile time reflection to find the fields in your classes. This generates the same code as a handwritten implementation would. It uses std.json on the backend and performance is mainly determined by the std.json implementation. At the moment of writing (2014) std.json is known to be slow compared to other languages. Hopefully, this will be improved over time.
 
 ## Tested compilers
-![DMD-2.068.0](https://img.shields.io/badge/DMD-2.068.0-brightgreen.svg)
-![DMD-2.067.1](https://img.shields.io/badge/DMD-2.067.1-brightgreen.svg)
-![DMD-2.066.1](https://img.shields.io/badge/DMD-2.066.1-brightgreen.svg)
-![DMD-2.065.0](https://img.shields.io/badge/DMD-2.065.0-red.svg)
-![LDC-0.15.1](https://img.shields.io/badge/LDC-0.15.1-brightgreen.svg)
-![GDC-4.9.2](https://img.shields.io/badge/GDC-4.9.2-brightgreen.svg)
+![DMD-2.087.0](https://img.shields.io/badge/DMD-2.087.0-brightgreen.svg)
+![DMD-2.086.1](https://img.shields.io/badge/DMD-2.086.1-brightgreen.svg)
+![DMD-2.085.1](https://img.shields.io/badge/DMD-2.085.1-brightgreen.svg)
+![DMD-2.084.1](https://img.shields.io/badge/DMD-2.084.1-brightgreen.svg)
+![DMD-2.083.1](https://img.shields.io/badge/DMD-2.083.1-brightgreen.svg)
+![DMD-2.082.1](https://img.shields.io/badge/DMD-2.082.1-brightgreen.svg)
+![DMD-2.081.2](https://img.shields.io/badge/DMD-2.081.2-brightgreen.svg)
+![DMD-2.080.1](https://img.shields.io/badge/DMD-2.080.1-brightgreen.svg)
+![DMD-2.079.1](https://img.shields.io/badge/DMD-2.079.1-brightgreen.svg)
+![DMD-2.078.3](https://img.shields.io/badge/DMD-2.078.3-brightgreen.svg)
+![DMD-2.077.1](https://img.shields.io/badge/DMD-2.077.1-brightgreen.svg)
+![DMD-2.076.1](https://img.shields.io/badge/DMD-2.076.1-brightgreen.svg)
+![DMD-2.075.1](https://img.shields.io/badge/DMD-2.075.1-red.svg)
+
+![LDC-1.16.0](https://img.shields.io/badge/LDC-1.16.0-brightgreen.svg)
+![LDC-1.15.0](https://img.shields.io/badge/LDC-1.15.0-brightgreen.svg)
+![LDC-1.14.0](https://img.shields.io/badge/LDC-1.14.0-brightgreen.svg)
+![LDC-1.13.0](https://img.shields.io/badge/LDC-1.13.0-brightgreen.svg)
+![LDC-1.12.0](https://img.shields.io/badge/LDC-1.12.0-brightgreen.svg)
+![LDC-1.11.0](https://img.shields.io/badge/LDC-1.11.0-brightgreen.svg)
+![LDC-1.10.0](https://img.shields.io/badge/LDC-1.10.0-brightgreen.svg)
+![LDC-1.9.0](https://img.shields.io/badge/LDC-1.9.0-brightgreen.svg)
+![LDC-1.8.0](https://img.shields.io/badge/LDC-1.8.0-brightgreen.svg)
+![LDC-1.7.0](https://img.shields.io/badge/LDC-1.7.0-brightgreen.svg)
+![LDC-1.6.0](https://img.shields.io/badge/LDC-1.6.0-brightgreen.svg)
+![LDC-1.5.0](https://img.shields.io/badge/LDC-1.5.0-red.svg)
+
+![GDC-8.2.1](https://img.shields.io/badge/GDC-8.2.1-red.svg)
 
 [master docs github]: http://blackedder.github.io/painlessjson/painlessjson.html
 [master docs ddocs]: http://ddocs.org/painlessjson/~master/painlessjson/painlessjson.html

--- a/source/painlessjson/painlessjson.d
+++ b/source/painlessjson/painlessjson.d
@@ -27,7 +27,18 @@ struct SerializationOptions
 
 enum defaultSerializatonOptions =  SerializationOptions(true, false);
 
-
+static if (is(typeof(JSONType.integer)))
+{
+    enum JSONType_int = JSONType.integer;
+    enum JSONType_true = JSONType.true_;
+    enum JSONType_null = JSONType.null_;
+}
+else
+{
+    enum JSONType_int = JSON_TYPE.INTEGER;
+    enum JSONType_true = JSON_TYPE.TRUE;
+    enum JSONType_null = JSON_TYPE.NULL;
+}
 
 
 
@@ -333,7 +344,7 @@ private T defaultFromJSONImpl(T, SerializationOptions options)(in JSONValue json
 
 private T defaultFromJSONImpl(T, SerializationOptions options)(in JSONValue json) if (isFloatingPoint!T)
 {
-    if (json.type == JSON_TYPE.INTEGER)
+    if (json.type == JSONType_int)
         return to!T(json.integer);
     else
         return to!T(json.floating);
@@ -346,7 +357,7 @@ private T defaultFromJSONImpl(T, SerializationOptions options)(in JSONValue json
 
 private T defaultFromJSONImpl(T, SerializationOptions options)(in JSONValue json) if (isBoolean!T)
 {
-    if (json.type == JSON_TYPE.TRUE)
+    if (json.type == JSONType_true)
         return true;
     else
         return false;
@@ -614,7 +625,7 @@ T fromJSON(T, SerializationOptions options = defaultSerializatonOptions)(in JSON
     }
     else 
     {
-        if (json.type == JSON_TYPE.NULL)
+        if (json.type == JSONType_null)
             return T.init;
         return defaultFromJSON!(T,options)(json);
     }

--- a/source/painlessjson/painlessjson.d
+++ b/source/painlessjson/painlessjson.d
@@ -86,8 +86,22 @@ private JSONValue defaultToJSONImpl(T, SerializationOptions options)(in T object
     return JSONValue(jsonAA);
 }
 
+// platform-independent tuple serializer using _0, _1, ... keys for unnamed keys (because key names could either be _0, _0UL or something else which is implmenetation defined)
+private JSONValue defaultToJSONImpl(T, SerializationOptions options)(in T object) if (is(T : Tuple!U, U...))
+{
+    JSONValue[string] jsonAA;
+    static foreach (i, name; T.fieldNames)
+    {
+        static if (name.length != 0)
+            jsonAA[name] = object[i].toJSON;
+        else
+            jsonAA["_" ~ (cast(int)i).to!string] = object[i].toJSON;
+    }
+    return JSONValue(jsonAA);
+}
+
 private JSONValue defaultToJSONImpl(T, SerializationOptions options )(in T object) if (!isBuiltinType!T
-        && !__traits(compiles, (in T t) { JSONValue(t); }))
+        && !is(T : Tuple!U, U...) && !__traits(compiles, (in T t) { JSONValue(t); }))
 {
     JSONValue[string] json;
     // Getting all member variables (there is probably an easier way)
@@ -99,7 +113,8 @@ private JSONValue defaultToJSONImpl(T, SerializationOptions options )(in T objec
                         object, name).toJSON;
                 }) && !hasAnyOfTheseAnnotations!(__traits(getMember, object,
             name), SerializeIgnore, SerializeToIgnore)
-            && isFieldOrProperty!(__traits(getMember, object, name)))
+            && isFieldOrProperty!(__traits(getMember, object, name))
+            && __traits(getProtection, __traits(getMember, object, name)) != "private")
         {
             json[serializationToName!(__traits(getMember, object, name), name,(options.convertToUnderscore))] = __traits(getMember,
                 object, name).toJSON;
@@ -403,11 +418,30 @@ private T defaultFromJSONImpl(T, SerializationOptions options)(in JSONValue json
     return t;
 }
 
+// Default tuple implementation
+private T defaultFromJSONImpl(T, SerializationOptions options)(in JSONValue json) if (is(T : Tuple!U, U...))
+{
+    T t;
+    const JSONValue[string] jsonAA = json.object;
+    static foreach (i, name; T.fieldNames)
+    {{
+        static if (name.length != 0)
+            enum effectiveName = name;
+        else
+            enum effectiveName = "_" ~ (cast(int)i).to!string;
+
+        if (auto v = effectiveName in jsonAA)
+            t[i] = fromJSON!(typeof(t[i]))(*v);
+    }}
+    return t;
+}
+
 /++
  Convert to given type from JSON.<br />
  Can be overridden by &#95;fromJSON.
  +/
-private T defaultFromJSONImpl(T, SerializationOptions options)(in JSONValue json) if (!isBuiltinType!T &&  !is(T == JSONValue))
+private T defaultFromJSONImpl(T, SerializationOptions options)(in JSONValue json)
+    if (!isBuiltinType!T &&  !is(T == JSONValue) && !is(T : Tuple!U, U...))
 {
     static if (hasAccessibleDefaultsConstructor!(T))
     {
@@ -482,6 +516,8 @@ private T defaultFromJSONImpl(T, SerializationOptions options)(in JSONValue json
                 "JSONValue can't satisfy any constructor: " ~ json.toPrettyString);
         }
     }
+    else static assert(false, "Cannot be automatically generate a defaultFromJSONImpl for type " ~ T.stringof
+        ~ ". (no accessible and suitable constructors) Create a _fromJSON member method for custom deserialization.");
 }
 
 /++
@@ -518,14 +554,12 @@ T getIntstanceFromDefaultConstructor(T)()
 
 T getInstanceFromCustomConstructor(T, alias Ctor, bool alsoAcceptUnderscore)(in JSONValue json)
 {
-    import std.typecons : staticIota;
-
     enum params = ParameterIdentifierTuple!(Ctor);
     alias defaults = ParameterDefaultValueTuple!(Ctor);
     alias Types = ParameterTypeTuple!(Ctor);
     Tuple!(Types) args;
-    foreach (i; staticIota!(0, params.length))
-    {
+    static foreach (i; 0 .. params.length)
+    {{
         enum paramName = params[i];
         if (paramName in json.object)
         {
@@ -546,7 +580,7 @@ T getInstanceFromCustomConstructor(T, alias Ctor, bool alsoAcceptUnderscore)(in 
                 args[i] = defaults[i];
             }
         }
-    }
+    }}
     static if (is(T == class))
     {
         return new T(args.expand);
@@ -559,40 +593,36 @@ T getInstanceFromCustomConstructor(T, alias Ctor, bool alsoAcceptUnderscore)(in 
 
 bool jsonValueHasAllFieldsNeeded(alias Ctor, bool alsoAcceptUnderscore)(in JSONValue json)
 {
-    import std.typecons : staticIota;
-
     enum params = ParameterIdentifierTuple!(Ctor);
     alias defaults = ParameterDefaultValueTuple!(Ctor);
     alias Types = ParameterTypeTuple!(Ctor);
     Tuple!(Types) args;
-    foreach (i; staticIota!(0, params.length))
-    {
+    static foreach (i; 0 .. params.length)
+    {{
         enum paramName = params[i];
         if (!((paramName in json.object) || ( alsoAcceptUnderscore && (camelCaseToUnderscore(paramName) in json.object))) && is(defaults[i] == void))
         {
             return false;
         }
-    }
+    }}
     return true;
 }
 
 ulong constructorOverloadScore(alias Ctor, bool alsoAcceptUnderscore)(in JSONValue json)
 {
-    import std.typecons : staticIota;
-
     enum params = ParameterIdentifierTuple!(Ctor);
     alias defaults = ParameterDefaultValueTuple!(Ctor);
     alias Types = ParameterTypeTuple!(Ctor);
     Tuple!(Types) args;
     ulong overloadScore = json.object.length;
-    foreach (i; staticIota!(0, params.length))
-    {
+    static foreach (i; 0 .. params.length)
+    {{
         enum paramName = params[i];
         if (paramName in json.object || ( alsoAcceptUnderscore && (camelCaseToUnderscore(paramName) in json.object)))
         {
             overloadScore--;
         }
-    }
+    }}
     return overloadScore;
 }
 


### PR DESCRIPTION
- change JSON_TYPE to JSONType with non-deprecated values (depending on the phobos version)
- removes access to private members in types
- adds properly defined tuple serialization
- upgrades static foreach code (min DMD-FE is now 2.076.0)
- updated tested compilers in README

This should definitely be a new minor version when released